### PR TITLE
Including invite script at header

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,4 +18,5 @@
     <link href="https://fonts.googleapis.com/icon?family=Lora" rel="stylesheet">
 
     {% if site.google_analytics %} {% include google_analytics.html %} {% endif %}
+    {% include invitation.html %}
 </head>

--- a/_includes/invitation.html
+++ b/_includes/invitation.html
@@ -1,0 +1,7 @@
+<script>
+  const urlParams = new URLSearchParams(window.location.search);
+  const invitationId = urlParams.get('invitation_id');
+  if (invitationId) {
+    localStorage.setItem('invitation-id', invitationId)
+  }
+</script>

--- a/_includes/retailer_sign_in_form.html
+++ b/_includes/retailer_sign_in_form.html
@@ -64,11 +64,6 @@
   }
 
   documentReady(() => {
-    const urlParams = new URLSearchParams(window.location.search);
-    const invitationId = urlParams.get('invitation_id');
-    if (invitationId) {
-      localStorage.setItem('invitation-id', invitationId)
-    }
     document.getElementById('invitation-id').value = localStorage.getItem('invitation-id');
   });
 


### PR DESCRIPTION
Eu tenho uma teoria chupacabras pro problema do Invitation_id.
Mesmo que nao seja esse o problema, o código ficou mais organizado.
O que eu reparei:
- A tela de fornecedor as vezes demora pra carregar numa internet lenta por conta das imagens da NASA. 
Minha teoria: Pode ser que esse povo tenha o dedo nervoso e queira saber o que é a gonddo quando cai na tela. Se a tela nao carregou por completo e ela clicar em qualquer outro lugar, o invitation_id se perde porque a url muda e o carregamento no localStorage só acontece no document ready

Solução. Coloquei em um arquivo separado (igual o analytics) no header. Ou seja, o site mal carregou e ja inseriu o dado no localStorage. 
