### PR TITLE
Corrige link do twitter inacessível ❌🖱️🐦

### DIFF
--- a/_scss/our_partners.scss
+++ b/_scss/our_partners.scss
@@ -29,7 +29,7 @@
 
 .gnd-carousel-container {
   width: 100%;
-  max-height: 16rem;
+  max-height: 22rem;
 }
 
 .gnd-our-partners-title {


### PR DESCRIPTION
Esse PR corrige um bug de CSS no carrossel da Home e Internas. O max-height estava menor que a altura do carrossel, então o conteúdo estava dando overflow no container e no caso da Home ficando sobre o ícone do Twitter :bird: impossibilitando o click :computer_mouse:.

**Antes Home**
![Screenshot from 2020-10-20 10-00-07](https://user-images.githubusercontent.com/1338285/96591380-93a33e00-12bd-11eb-8aab-9b35c3452f34.png)

**Depois Home**
![Screenshot from 2020-10-20 10-00-52](https://user-images.githubusercontent.com/1338285/96590841-e16b7680-12bc-11eb-828a-8c3c7effc576.png)

**Antes Interna**
![Screenshot from 2020-10-20 10-11-11](https://user-images.githubusercontent.com/1338285/96590903-f7793700-12bc-11eb-9e66-7d5d772ad033.png)

**Depois Interna**
![Screenshot from 2020-10-20 10-11-03](https://user-images.githubusercontent.com/1338285/96591565-bfbebf00-12bd-11eb-944c-d2c56e842a7a.png)
(Não dá pra ver direito mas o cinza vem até o final da página, antes ficava um teco branco)